### PR TITLE
Use dynamic thread parking instead of fixed schedule for timer

### DIFF
--- a/src/system.rs
+++ b/src/system.rs
@@ -517,7 +517,7 @@ impl ActorSystem {
     pub fn shutdown(&self) -> Shutdown {
         let (tx, rx) = oneshot::channel::<()>();
         let tx = Arc::new(Mutex::new(Some(tx)));
-
+        self.timer.stop();
         self.tmp_actor_of_args::<ShutdownActor, _>(tx).unwrap();
 
         rx

--- a/src/system.rs
+++ b/src/system.rs
@@ -319,7 +319,7 @@ impl ActorSystem {
         }
 
         let prov = Provider::new(log.clone());
-        let timer = BasicTimer::start(&cfg);
+        let timer = BasicTimer::start();
 
         // 1. create proto system
         let proto = ProtoSystem {

--- a/src/system/timer.rs
+++ b/src/system/timer.rs
@@ -58,6 +58,7 @@ pub enum Job {
     Once(OnceJob),
     Repeat(RepeatJob),
     Cancel(Uuid),
+    Shutdown,
 }
 
 pub struct OnceJob {
@@ -112,6 +113,11 @@ impl TimerRef {
         self.thread.unpark();
         result
     }
+
+    pub(crate) fn stop(&self) {
+        self.sender.send(Job::Shutdown).expect("Failed to stop shutdown to timer");
+        self.thread.unpark();
+    }
 }
 
 
@@ -131,6 +137,7 @@ impl BasicTimer {
                     Job::Cancel(id) => process.cancel(&id),
                     Job::Once(job) => process.schedule_once(job),
                     Job::Repeat(job) => process.schedule_repeat(job),
+                    Job::Shutdown => return,
                 }
             }
 

--- a/src/system/timer.rs
+++ b/src/system/timer.rs
@@ -3,17 +3,16 @@ use std::{
     thread,
     time::{Duration, Instant},
 };
+use std::cmp::min;
+use std::sync::mpsc::SendError;
 
 use chrono::{DateTime, Utc};
-use config::Config;
 use uuid::Uuid;
 
 use crate::{
     actor::{ActorRef, BasicActorRef, Sender},
     AnyMessage, Message,
 };
-
-pub type TimerRef = mpsc::Sender<Job>;
 
 pub type ScheduleId = Uuid;
 
@@ -92,27 +91,41 @@ impl RepeatJob {
     }
 }
 
-// Default timer implementation
+// Default timer implementation using a separate thread that is repeatedly
+// parked while waiting for the next job and unparked to either process
+// incoming commands or scheduled jobs
 
 pub struct BasicTimer {
     once_jobs: Vec<OnceJob>,
     repeat_jobs: Vec<RepeatJob>,
 }
 
-impl BasicTimer {
-    pub fn start(cfg: &Config) -> TimerRef {
-        let cfg = BasicTimerConfig::from(cfg);
+#[derive(Clone)]
+pub struct TimerRef {
+    thread: std::thread::Thread,
+    sender: mpsc::Sender<Job>,
+}
 
+impl TimerRef {
+    pub fn send(&self, job: Job) -> Result<(), SendError<Job>> {
+        let result = self.sender.send(job);
+        self.thread.unpark();
+        result
+    }
+}
+
+
+impl BasicTimer {
+    pub fn start() -> TimerRef {
         let mut process = BasicTimer {
             once_jobs: Vec::new(),
             repeat_jobs: Vec::new(),
         };
 
         let (tx, rx) = mpsc::channel();
-        thread::spawn(move || loop {
-            process.execute_once_jobs();
-            process.execute_repeat_jobs();
-
+        let join_handle = thread::spawn(move || loop {
+            // first check whether there are new messages to process
+            // in case a new job is scheduled, it should be executed immediately if desired
             if let Ok(job) = rx.try_recv() {
                 match job {
                     Job::Cancel(id) => process.cancel(&id),
@@ -121,13 +134,28 @@ impl BasicTimer {
                 }
             }
 
-            thread::sleep(Duration::from_millis(cfg.frequency_millis));
+            // a default park timeout duration in case there's nothing else to do
+            let mut park_for = Duration::MAX;
+
+            if let Some(time_left) = process.execute_once_jobs() {
+                park_for = min(time_left, park_for);
+            }
+            if let Some(time_left) = process.execute_repeat_jobs() {
+                park_for = min(time_left, park_for);
+            }
+
+            thread::park_timeout(park_for);
         });
 
-        tx
+        TimerRef {
+            thread: join_handle.thread().clone(),
+            sender: tx
+        }
     }
 
-    pub fn execute_once_jobs(&mut self) {
+    /// Runs all jobs that have been scheduled to run once and which are due
+    /// If there are jobs left, return the duration until the next one is due
+    fn execute_once_jobs(&mut self) -> Option<Duration> {
         let (send, keep): (Vec<OnceJob>, Vec<OnceJob>) = self
             .once_jobs
             .drain(..)
@@ -138,19 +166,39 @@ impl BasicTimer {
             job.send();
         }
 
+        if keep.is_empty() {
+            return None;
+        }
+
         // for those messages that are not to be sent yet, just put them back on the vec
+        let mut next_job = Duration::MAX;
+        let now = Instant::now();
         for job in keep {
+            let time_left = job.send_at.duration_since(now);
+            next_job = min(next_job, time_left);
             self.once_jobs.push(job);
         }
+        Some(next_job)
     }
 
-    pub fn execute_repeat_jobs(&mut self) {
-        for job in self.repeat_jobs.iter_mut() {
-            if Instant::now() >= job.send_at {
-                job.send_at = Instant::now() + job.interval;
-                job.send();
-            }
+    /// Executes all repeat jobs that are due and returns the duration until the next is due
+    fn execute_repeat_jobs(&mut self) -> Option<Duration> {
+        if self.repeat_jobs.is_empty() {
+            return None;
         }
+        let mut time_left = Duration::MAX;
+        let now =  Instant::now();
+        for job in self.repeat_jobs.iter_mut() {
+            let next_scheduled_run_in = if now >= job.send_at {
+                job.send_at = now + job.interval;
+                job.send();
+                job.interval
+            } else {
+                job.send_at.duration_since(now)
+            };
+            time_left = min(next_scheduled_run_in, time_left);
+        }
+        Some(time_left)
     }
 
     pub fn cancel(&mut self, id: &Uuid) {
@@ -179,17 +227,5 @@ impl BasicTimer {
             job.send();
         }
         self.repeat_jobs.push(job);
-    }
-}
-
-struct BasicTimerConfig {
-    frequency_millis: u64,
-}
-
-impl<'a> From<&'a Config> for BasicTimerConfig {
-    fn from(config: &Config) -> Self {
-        BasicTimerConfig {
-            frequency_millis: config.get_int("scheduler.frequency_millis").unwrap() as u64,
-        }
     }
 }


### PR DESCRIPTION
There is some duplication going on that I'm not too happy about. Kindly have a look and let me know what you think.

Also I think that the `Drop` trait should be implemented for `TimerRef` so it can properly shut down the thread when the owning `ActorSystem` gets dropped, which doesn't seem to be happening anywhere.

On a positive note, I pointed our `libbraccus` to use this branch and the number of times it was polled went up to the exact expected amount :tada: 